### PR TITLE
Add a new route that can execute a function without saving it

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Using [Docker](https://www.docker.com/), start the service (be sure to replace &
 
 > You can find the latest version on [DockerHub](https://cloud.docker.com/u/titanclass/repository/docker/titanclass/jsaas/tags)
 
+### Define and Execute
+
 ```bash
 docker run -e JSAAS_BIND_ADDR=0.0.0.0:9412 -p 9412:9412 --rm -ti titanclass/jsaas:<version>
 ```
@@ -39,6 +41,20 @@ which yields:
 ```
 
 In a real-world scenario, you can also return a JS object or any other JSON-serializable value.
+
+### Execute Once
+
+You can also supply a function to be evaluated in one request and immediately discarded.
+
+```bash
+curl -XPOST --data 'function() { return 8 * 2; }' http://localhost:9412/execute
+```
+
+which yields:
+
+```
+16
+```
 
 ## Configuration
 

--- a/tests/jsaas_integration_test.rs
+++ b/tests/jsaas_integration_test.rs
@@ -56,6 +56,18 @@ fn test_jsaas() {
             .unwrap();
 
         assert_eq!(value, 12);
+
+        let value2 = client
+            .post("http://localhost:9412/execute")
+            .body("function() { return 2 + 2 * 2; }")
+            .send()
+            .unwrap()
+            .text()
+            .unwrap()
+            .parse::<i64>()
+            .unwrap();
+
+        assert_eq!(value2, 6);
     });
 }
 


### PR DESCRIPTION
Curious to get your thoughts on the following:

A) Route name (currently simply `/execute`)
B) Input format. Currently, it simply executes a parameterless-function that is specified as the payload. It would be easy to take arguments in a JSON format as an HTTP header, but quite a bit harder to use multi-part payloads given that Hyper is rather lowlevel.

Use-case: Executing test suite without storing anything on the server.